### PR TITLE
To prevent a break in your next push :)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,4 @@ gem 'narray' #, :git => "https://github.com/tonyarnold/narray"
 gem 'rb-gsl'
 #gem 'gsl', :git => "https://github.com/tonyarnold/rb-gsl"
 #gem 'gsl', :git => 'git://github.com/siefca/rb-gsl'
+gem 'latex-decode', '0.2.2' # There seems to be a problem with 0.3.0.

--- a/Gemfile
+++ b/Gemfile
@@ -32,4 +32,5 @@ gem 'narray' #, :git => "https://github.com/tonyarnold/narray"
 gem 'rb-gsl'
 #gem 'gsl', :git => "https://github.com/tonyarnold/rb-gsl"
 #gem 'gsl', :git => 'git://github.com/siefca/rb-gsl'
-gem 'latex-decode', '0.2.2' # There seems to be a problem with 0.3.0.
+gem 'latex-decode', '>=0.3.1' #'0.2.2' # There seems to be a problem with 0.3.0.
+gem 'citeproc', '>=1.0.6' # This is intended to work with the change on latex-decode v0.3.1. See https://github.com/inukshuk/citeproc-ruby/issues/16#issuecomment-342436167

--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,4 @@ gem 'rb-gsl'
 #gem 'gsl', :git => 'git://github.com/siefca/rb-gsl'
 gem 'latex-decode', '>=0.3.1' #'0.2.2' # There seems to be a problem with 0.3.0.
 gem 'citeproc', '>=1.0.6' # This is intended to work with the change on latex-decode v0.3.1. See https://github.com/inukshuk/citeproc-ruby/issues/16#issuecomment-342436167
+gem 'unicode' # Might be required for Ruby older than 2.3.

--- a/_config.yml
+++ b/_config.yml
@@ -45,6 +45,7 @@ sourcebranch: dev # used in linking commit history.
 source: .
 gems:
   - jekyll-pandoc
+  - unicode # Maybe required by latex-decode 0.3.
 #  - 'jekyll-twitter-plugin'
 # Publications. Ref: http://tuxette.nathalievilla.org/?p=1426
 # http://eric-tramel.github.io/working-automated-publications/


### PR DESCRIPTION
The `latex-decode` v0.3.0 may break things for you. This path will prevent you from updating to the bad version. See [issue here](https://github.com/inukshuk/citeproc-ruby/issues/16).